### PR TITLE
appengine dropdown fixed

### DIFF
--- a/appengine-frontend/package-lock.json
+++ b/appengine-frontend/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "appengine-frontend",
             "license": "Apache-2.0",
             "dependencies": {
                 "express": "^4.17.1",

--- a/appengine-frontend/public/css/style.css
+++ b/appengine-frontend/public/css/style.css
@@ -55,3 +55,33 @@ strong {
 @media screen and (max-width: 1040px) {
  
 }
+/* Styling for the select dropdown */
+select {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 16px;
+  width: 100%;
+  max-width: 300px;
+  background-color: #f7f7f7;
+  color: #333;
+}
+
+/* Styling for the select dropdown when hovered */
+select:hover {
+  border-color: #aaa;
+}
+
+/* Styling for the select dropdown when focused */
+select:focus {
+  outline: none;
+  border-color: #66afe9;
+  box-shadow: 0 0 5px rgba(102, 175, 233, 0.5);
+}
+
+/* Styling for the select dropdown options */
+option {
+  padding: 8px;
+  background-color: #f7f7f7;
+  color: #333;
+}

--- a/appengine-frontend/public/html/index.html
+++ b/appengine-frontend/public/html/index.html
@@ -19,19 +19,20 @@
     </h1>
 
     <div id="filter">
-        <sl-select id="language-select" placeholder="Select a language..." clearable>
-            <sl-menu-item value="English">English</sl-menu-item>
-            <sl-menu-item value="French">French</sl-menu-item>
-            <sl-menu-item value="German">German</sl-menu-item>
-            <sl-menu-item value="Russian">Russian</sl-menu-item>
-            <sl-menu-item value="Italian">Italian</sl-menu-item>
-            <sl-menu-item value="Arabic">Arabic</sl-menu-item>
-            <sl-menu-item value="Greek">Greek</sl-menu-item>
-            <sl-menu-item value="Portuguese">Portuguese</sl-menu-item>
-            <sl-menu-item value="Sanskrit">Sanskrit</sl-menu-item>
-            <sl-menu-item value="Norwegian">Norwegian</sl-menu-item>
-            <sl-menu-item value="Japanese">Japanese</sl-menu-item>
-        </sl-select>
+        <select id="language-select"  clearable>
+            <option value="" selected>All Languages</option>
+            <option value="English">English</option>
+            <option value="French">French</option>
+            <option value="German">German</option>
+            <option value="Russian">Russian</option>
+            <option value="Italian">Italian</option>
+            <option value="Arabic">Arabic</option>
+            <option value="Greek">Greek</option>
+            <option value="Portuguese">Portuguese</option>
+            <option value="Sanskrit">Sanskrit</option>
+            <option value="Norwegian">Norwegian</option>
+            <option value="Japanese">Japanese</option>
+        </select>
         <br/>
     </div>    
 

--- a/appengine-frontend/public/js/app.js
+++ b/appengine-frontend/public/js/app.js
@@ -18,9 +18,9 @@ document.addEventListener("DOMContentLoaded", async function(event) {
     });
 
     const langSelect = document.getElementById('language-select');
-    langSelect.addEventListener('sl-change', event => {
+    langSelect.addEventListener('change', event => {
         page = 0;
-        language = event.srcElement.value;
+        language = event.target.value;
         document.getElementById('library').replaceChildren();
         console.log(`Language selected: "${language}"`);
 


### PR DESCRIPTION
The dropdown in App Engine wasn't working properly and has been fixed.
The select tag is used instead of sl-select as it was causing errors and the option tag is used in place of sl-menu in index.html.  
The main.css was updated to style these newly added tags.
The app.js file was updated to listen to changes in select dropdown and the deprecated srcElement was replaced by target.
Thank you,
Bhaarat Krishnan
